### PR TITLE
fix(CacheService): clean `crashed` flight🐛

### DIFF
--- a/src/app/cache.service.ts
+++ b/src/app/cache.service.ts
@@ -39,7 +39,14 @@ export class CacheService {
     } else if (fallback && fallback instanceof Observable) {
       this.inFlightObservables.set(key, new Subject());
       console.log(`%c Calling api for ${key}`, 'color: purple');
-      return fallback.do((value) => { this.set(key, value, maxAge); });
+      return fallback.do((value) => { this.set(key, value, maxAge); })
+        .catch((e: any) => { // `fallback` are crashed
+          // crashed flight is terrible😰, it's better to clean it up...
+          this.inFlightObservables.delete(key);
+          // and when we have done our job, it's good idea to let the others know this event.
+          // maybe they have their stuffs need to be done too.
+          return Observable.throw(e);
+      });
     } else {
       return Observable.throw('Requested key is not available in Cache');
     }


### PR DESCRIPTION
I have done a small fix for your `CacheService`, please check it out.

The problem is when a key got added to `inFlightObservables` and it's corresponding `fallback` got thrown, any consequences request with same key will never got it's response. 

You can see my demo for this problem at
https://stackblitz.com/edit/angular-simple-cache-service-with-rxjs-lqmx3k?file=app%2Fhackernews.service.ts